### PR TITLE
Allow active{support,record} >= 4.0.0

### DIFF
--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/state_of_the_nation.gemspec
+++ b/state_of_the_nation.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Patrick O'Doherty", "Stephen O'Brien"]
   spec.email         = ["patrick@intercom.io", "stephen@intercom.io"]
 
-  spec.summary       = %q{An easy way to model state changes over time}
+  spec.summary       = %q{An easy way to model state that changes over time with ActiveRecord}
   spec.description   = %q{State of the Nation makes modeling object history easy.}
   spec.homepage      = "https://github.com/intercom/state_of_the_nation"
   spec.licenses      = ["Apache License, Version 2.0"]
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-matchers"
   spec.add_development_dependency "sqlite3"
 
-  spec.add_runtime_dependency "activesupport", "~> 4.2"
-  spec.add_runtime_dependency "activerecord", "~> 4.2"
+  spec.add_runtime_dependency "activesupport", ">= 4.0.0"
+  spec.add_runtime_dependency "activerecord", ">= 4.0.0"
 end


### PR DESCRIPTION
Widen our compatibility with slightly older ActiveSupport and ActiveRecord
dependencies. Both were released as 4.0 in mid 2013 which I think is a
comfortable level of backwards compatibility. If we need to go further we can
explore at a later day.

Bump to 1.0.1 to acknowledge this change
