### PR TITLE
Round timestamps for appropriate Database adaptors

### DIFF
--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -316,4 +316,29 @@ describe StateOfTheNation do
       end
     end
   end
+
+  context "#should_round_timestamps?" do
+    let(:country) { Country.create }
+    let!(:washington) { country.presidents.create!(entered_office_at: day(1), left_office_at: day(8)) }
+    let(:sub_second_timestamp) { 1270643035.04671 }
+    let(:sub_second_time) { Time.at(sub_second_timestamp)  }
+
+    it "is true for MySQL" do
+      allow(President).to receive_message_chain(:connection, :adapter_name).
+        and_return("MySQL")
+      expect(washington.send(:should_round_timestamps?)).to eq(true)
+    end
+
+    it "is false for PostgreSQL" do
+      allow(President).to receive_message_chain(:connection, :adapter_name).
+                           and_return("PostgreSQL")
+      expect(washington.send(:should_round_timestamps?)).to eq(false)
+    end
+
+    it "is true for SQLite" do
+      allow(President).to receive_message_chain(:connection, :adapter_name).
+                           and_return("SQLite")
+      expect(washington.send(:should_round_timestamps?)).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
MySQL and PostgreSQL differ in that they store different resolution timestamps
in their respective datetime and timestamp fields. This can lead to issues,
specifically with MySQL where an `active?` comparison might not work due to the
passed application timestamp having millisecond values different to the
retrieved column value.

To prevent these false-negative errors we'll round the timestamps where
appropriate, leaving them untouched if the database supports a finer resolution
timestamp.
