### PR TITLE
Add optional IdentityCache support

### DIFF
--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -57,7 +57,8 @@ module StateOfTheNation
 
       define_method "active_#{association}" do |time = Time.now.utc|
         time = should_round_timestamps? ? time.round : time
-        collection = send(plural.to_sym).select { |r| r.send("active?", time) }
+        method_name = respond_to?(fetch_method = "fetch_#{plural}") ? fetch_method : plural.to_sym
+        collection = send(method_name).select { |r| r.send("active?", time) }
         single ? collection.first : collection
       end
     end

--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -341,4 +341,25 @@ describe StateOfTheNation do
       expect(washington.send(:should_round_timestamps?)).to eq(true)
     end
   end
+
+  context "IdentityCache support" do
+    let(:country) { Country.create }
+    let!(:washington) { country.presidents.create!(entered_office_at: day(1), left_office_at: day(8)) }
+
+    it "uses the fetch_ method if available" do
+      module IdentityCache
+        def fetch_presidents
+          self.presidents
+        end
+      end
+
+      class Country
+        include IdentityCache
+      end
+
+      expect(country).to receive(:fetch_presidents).
+        and_call_original
+      expect(country.active_president(day(7))).to eq(washington)
+    end
+  end
 end


### PR DESCRIPTION
If we can detect the presence of the fetch_ prefixed IdentityCache methods for
retrieving a list of child records from the cache we will use this method in
place of a direct database query, and then run an in-memory selection to return
the active records.