### PR TITLE
Add IdentityCache support for parent-child relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ usa.active_senators(Date.new(2015, 1, 1))
 
 
 ```
+## IdentityCache Support
+
+StateOfTheNation optionally supports fetching child records out of an IdentityCache cache instead of reading directly from the SQL table. 
+
+For example if the Country model uses IdentityCache to cache the has_many relationship to President, you can make StateOfTheNation use the IdentityCache methods by calling `.with_identity_cache` on your `has_active` or `has_uniquely_active` definitions like so.
+
+```ruby
+class Country
+  include IdentityCache
+  include StateOfTheNation
+  
+  has_many(:presidents)
+  cache_has_many(:presidents)
+  has_uniquely_active(:president).with_identity_cache
+end
+```
+
+Now every time the `Country#active_president` method is called StateOfTheNation will read through the IdentityCache methods and avoid a SELECT operation if possible.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -341,4 +341,35 @@ describe StateOfTheNation do
       expect(washington.send(:should_round_timestamps?)).to eq(true)
     end
   end
+
+  context "IdentityCache support" do
+    before do
+      # Mock up of the IdentityCache methods
+      module IdentityCache
+        def fetch_presidents
+          self.presidents
+        end
+      end
+
+      class Country < ActiveRecord::Base
+        include StateOfTheNation
+        include IdentityCache 
+
+        has_many :presidents
+
+        has_uniquely_active(:president).with_identity_cache
+      end
+    end
+
+    let(:country) { Country.create }
+    let!(:president) { country.presidents.create!(entered_office_at: day(1), left_office_at: day(8)) }
+
+    context ".using_identity_cache" do
+      it "uses the fetch_method to retrieve records" do
+        expect(country).to receive(:fetch_presidents)
+          .and_call_original
+        expect(country.active_president(day(7))).to eq(president)
+      end
+    end
+  end
 end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -344,16 +344,8 @@ describe StateOfTheNation do
 
   context "IdentityCache support" do
     before do
-      # Mock up of the IdentityCache methods
-      module IdentityCache
-        def fetch_presidents
-          self.presidents
-        end
-      end
-
       class Country < ActiveRecord::Base
         include StateOfTheNation
-        include IdentityCache 
 
         has_many :presidents
 
@@ -367,7 +359,7 @@ describe StateOfTheNation do
     context ".using_identity_cache" do
       it "uses the fetch_method to retrieve records" do
         expect(country).to receive(:fetch_presidents)
-          .and_call_original
+          .and_return([president])
         expect(country.active_president(day(7))).to eq(president)
       end
     end


### PR DESCRIPTION
IdentityCache provides an easy to use caching layer on top of ActiveRecord
associations, creating instance methods on models with a fetch_ prefix denoting
the use of a cache. For example in our documentation case adding IdentityCache
to Countries with `cache_has_many :presidents` would create a
`fetch_presidents` method which uses the cache instead of directly querying the
SQL table.

We allow the use of this cache by calling `.with_identity_cache` on any
`has_active` or `has_uniquely_active` relationship where the parent class
includes IdentityCache and exposes these caching methods.