### PR TITLE
Uniformly round timestamps where required

### DIFF
--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
A previous attempt to introduce automatic timestamp rounding based on the
ActiveRecord adaptor introduced an intermittent bug where comparison of
timestamps would not work due to comparing rounded and non-rounded values.

To mitigate these we now round *all* timestamps uniformly if required to do so,
not just certain values that we're taking as inputs for comparison.

Bumping the version to 1.1.1 to reflect this bug fix.