### PR TITLE
Fix rounding exceptions with non-Time values

### DIFF
--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -77,8 +77,8 @@ module StateOfTheNation
     end
 
     def round_if_should(time)
-      return time.round if should_round_timestamps?
-      time
+      return time if !should_round_timestamps?
+      time.respond_to?(:round) ? time.round : time
     end
 
     def should_round_timestamps?

--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -352,6 +352,17 @@ describe StateOfTheNation do
         has_uniquely_active(:president).with_identity_cache
       end
     end
+    after do
+      class Country < ActiveRecord::Base
+        include StateOfTheNation
+
+        has_many :presidents
+        has_many :senators
+
+        has_uniquely_active(:president)
+        has_active(:senators)
+      end
+    end
 
     let(:country) { Country.create }
     let!(:president) { country.presidents.create!(entered_office_at: day(1), left_office_at: day(8)) }
@@ -362,6 +373,17 @@ describe StateOfTheNation do
           .and_return([president])
         expect(country.active_president(day(7))).to eq(president)
       end
+    end
+  end
+
+  context "creating records with non-Time values" do
+    let(:country) { Country.create }
+    it "works" do
+      washington = country.presidents.create!(
+        entered_office_at: Date.new(1789, 4, 30),
+        left_office_at: Date.new(1797, 5, 4)
+      )
+      expect(country.active_president(Date.new(1790, 1, 1))).to eq(washington)
     end
   end
 end


### PR DESCRIPTION
Time-like values like Date don't have a #round instance method and so throw
exceptions when used in situations where StateOfTheNation thinks we should
round all values before comparison.

We now only round objects which expose the method, otherwise returning the
object unaltered.

Bump to 1.1.2 to release this bugfix