### PR TITLE
Add helpful message to ConflictError

### DIFF
--- a/lib/state_of_the_nation/errors/configuration_error.rb
+++ b/lib/state_of_the_nation/errors/configuration_error.rb
@@ -1,4 +1,3 @@
 module StateOfTheNation
   ConfigurationError = Class.new(StandardError)
-  ConflictError = Class.new(StandardError)
 end

--- a/lib/state_of_the_nation/errors/conflict_error.rb
+++ b/lib/state_of_the_nation/errors/conflict_error.rb
@@ -1,0 +1,16 @@
+module StateOfTheNation
+  class ConflictError < StandardError
+    def initialize(record, conflicting_records)
+      super(<<-MSG.strip_heredoc)
+        Attempted to commit record
+
+          #{record.inspect}
+
+        But encountered a conflict with timestamps on the following records
+
+          #{conflicting_records.map { |record| "- #{record.inspect}" }.join("\n")}
+
+      MSG
+    end
+  end
+end

--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end


### PR DESCRIPTION
It currently requires a lot of digging to figure out _which_ model caused the overlap. This leads to errors like the following:

```
StateOfTheNation::ConflictError: Attempted to commit record

  #<President id: nil, entered_office_at: "1970-01-06 00:00:00", left_office_at: "1970-01-13 00:00:00", country_id: 1, comment: nil>

But encountered a conflict with timestamps on the following records

  - #<President id: 1, entered_office_at: "1970-01-02 00:00:00", left_office_at: "1970-01-11 00:00:00", country_id: 1, comment: nil>
```

Bumped the version, but maybe shouldn't have? Not sure what the publication process is for this gem.