### PR TITLE
Ignore records where there is no difference between start and finish

### DIFF
--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -13,9 +13,11 @@ module StateOfTheNation
   end
 
   module ClassMethods
-    attr_accessor :prevent_multiple_active, :parent_association, :start_key, :finish_key
+    attr_accessor :prevent_multiple_active, :parent_association, :start_key, :finish_key, :ignore_empty
 
-    def considered_active
+    def considered_active(ignore_empty: false)
+      @ignore_empty = ignore_empty
+
       def from(start_key)
         @start_key = start_key
         self
@@ -127,6 +129,9 @@ module StateOfTheNation
     # find competing records which *finish* being active AFTER this record *starts* being active
     # (or ones which are not set to finish being active)
 
+    records = records.where(QueryString.query_for(:start_and_finish_not_equal, self.class)) if ignore_empty
+    # exclude records where there is no difference between start and finish dates
+
     records
   end
 
@@ -165,6 +170,10 @@ module StateOfTheNation
 
   def finish_key
     self.class.finish_key
+  end
+
+  def ignore_empty
+    self.class.ignore_empty
   end
 
   def should_round_timestamps?

--- a/lib/state_of_the_nation/query_string.rb
+++ b/lib/state_of_the_nation/query_string.rb
@@ -10,11 +10,13 @@ module StateOfTheNation
           active_scope: "(%{finish_key} IS NULL OR %{finish_key} > ?::timestamp) AND %{start_key} <= ?::timestamp",
           less_than: "(%{start_key} < ?::timestamp)",
           greater_than_or_null: "(%{finish_key} > ?::timestamp) OR (%{finish_key} IS NULL)",
+          start_and_finish_not_equal: "(%{start_key} != %{finish_key})",
         },
         mysql: {
           active_scope: "(%{finish_key} IS NULL OR %{finish_key} > ?) AND %{start_key} <= ?",
           less_than: "(%{start_key} < ?)",
-          greater_than_or_null: "(%{finish_key} > ?) OR (%{finish_key} IS NULL)"
+          greater_than_or_null: "(%{finish_key} > ?) OR (%{finish_key} IS NULL)",
+          start_and_finish_not_equal: "(%{start_key} != %{finish_key})"
         }
       }[appropriate_db_type(klass)]
     end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -268,7 +268,7 @@ describe StateOfTheNation do
       expect { pres1; pres5 }.not_to raise_error
     end
 
-    it "raises an exception if existing model is a no-op" do
+    it "raises an exception if existing model has an empty activation interval" do
       expect { pres6; pres1 }.to raise_error StateOfTheNation::ConflictError
     end
 

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -272,7 +272,7 @@ describe StateOfTheNation do
       expect { pres6; pres1 }.to raise_error StateOfTheNation::ConflictError
     end
 
-    it "does nothing if existing model is a no-op and no-ops ignored" do
+    it "does nothing if existing model has an empty activation interval and empty intervals are ignored" do
       allow(President).to receive(:ignore_empty).and_return(true)
 
       expect { pres6; pres1 }.not_to raise_error

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -251,6 +251,7 @@ describe StateOfTheNation do
     let(:pres3) { country.presidents.create!(entered_office_at: day(10), left_office_at: day(12)) }
     let(:pres4) { country.presidents.create!(entered_office_at: day(15), left_office_at: day(22)) }
     let(:pres5) { President.create!(entered_office_at: pres1.entered_office_at, left_office_at: pres1.left_office_at) }
+    let(:pres6) { country.presidents.create!(entered_office_at: day(5), left_office_at: day(5)) }
 
     it "raises an exception if multiple active would have occurred from creation" do
       expect { pres1; pres2 }.to raise_error StateOfTheNation::ConflictError
@@ -265,6 +266,16 @@ describe StateOfTheNation do
 
     it "does nothing if it’s not associated to scoped model yet" do
       expect { pres1; pres5 }.not_to raise_error
+    end
+
+    it "raises an exception if existing model is a no-op" do
+      expect { pres6; pres1 }.to raise_error StateOfTheNation::ConflictError
+    end
+
+    it "does nothing if existing model is a no-op and no-ops ignored" do
+      allow(President).to receive(:ignore_empty).and_return(true)
+
+      expect { pres6; pres1 }.not_to raise_error
     end
 
     it "does nothing if prevent_multiple_active is set to false" do

--- a/state_of_the_nation.gemspec
+++ b/state_of_the_nation.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
At the moment it is not possible to create a new record that starts before and ends after an existing. This is the whole point of this gem but in cases where it's not possible to delete records it may be required to ignore certain records.

This allows for the creation of records of new entries that span the `from` and `until` values of existing entries if the there is difference in those values, essentially making it a no-op.