### PR TITLE
Considered active for non terminated periods

### DIFF
--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -129,8 +129,9 @@ module StateOfTheNation
     # find competing records which *finish* being active AFTER this record *starts* being active
     # (or ones which are not set to finish being active)
 
-    records = records.where(QueryString.query_for(:start_and_finish_not_equal_and_not_null, self.class)) if ignore_empty
+    records = records.where(QueryString.query_for(:start_and_finish_not_equal_or_are_null, self.class)) if ignore_empty
     # exclude records where there is no difference between start and finish dates
+    # (we need to deliberately not filter out records with null value keys with this comparison as not equal comparisons to null are always deemed null/false)
 
     records
   end

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -129,7 +129,7 @@ module StateOfTheNation
     # find competing records which *finish* being active AFTER this record *starts* being active
     # (or ones which are not set to finish being active)
 
-    records = records.where(QueryString.query_for(:start_and_finish_not_equal, self.class)) if ignore_empty
+    records = records.where(QueryString.query_for(:start_and_finish_not_equal_and_not_null, self.class)) if ignore_empty
     # exclude records where there is no difference between start and finish dates
 
     records

--- a/lib/state_of_the_nation/query_string.rb
+++ b/lib/state_of_the_nation/query_string.rb
@@ -10,13 +10,13 @@ module StateOfTheNation
           active_scope: "(%{finish_key} IS NULL OR %{finish_key} > ?::timestamp) AND %{start_key} <= ?::timestamp",
           less_than: "(%{start_key} < ?::timestamp)",
           greater_than_or_null: "(%{finish_key} > ?::timestamp) OR (%{finish_key} IS NULL)",
-          start_and_finish_not_equal_and_not_null: "(%{start_key} != %{finish_key}) OR (%{start_key} IS NULL) OR (%{finish_key} IS NULL)",
+          start_and_finish_not_equal_or_are_null: "(%{start_key} != %{finish_key}) OR (%{start_key} IS NULL) OR (%{finish_key} IS NULL)",
         },
         mysql: {
           active_scope: "(%{finish_key} IS NULL OR %{finish_key} > ?) AND %{start_key} <= ?",
           less_than: "(%{start_key} < ?)",
           greater_than_or_null: "(%{finish_key} > ?) OR (%{finish_key} IS NULL)",
-          start_and_finish_not_equal_and_not_null: "(%{start_key} != %{finish_key}) OR (%{start_key} IS NULL) OR (%{finish_key} IS NULL)"
+          start_and_finish_not_equal_or_are_null: "(%{start_key} != %{finish_key}) OR (%{start_key} IS NULL) OR (%{finish_key} IS NULL)"
         }
       }[appropriate_db_type(klass)]
     end

--- a/lib/state_of_the_nation/query_string.rb
+++ b/lib/state_of_the_nation/query_string.rb
@@ -10,13 +10,13 @@ module StateOfTheNation
           active_scope: "(%{finish_key} IS NULL OR %{finish_key} > ?::timestamp) AND %{start_key} <= ?::timestamp",
           less_than: "(%{start_key} < ?::timestamp)",
           greater_than_or_null: "(%{finish_key} > ?::timestamp) OR (%{finish_key} IS NULL)",
-          start_and_finish_not_equal: "(%{start_key} != %{finish_key})",
+          start_and_finish_not_equal_and_not_null: "(%{start_key} != %{finish_key}) OR (%{start_key} IS NULL) OR (%{finish_key} IS NULL)",
         },
         mysql: {
           active_scope: "(%{finish_key} IS NULL OR %{finish_key} > ?) AND %{start_key} <= ?",
           less_than: "(%{start_key} < ?)",
           greater_than_or_null: "(%{finish_key} > ?) OR (%{finish_key} IS NULL)",
-          start_and_finish_not_equal: "(%{start_key} != %{finish_key})"
+          start_and_finish_not_equal_and_not_null: "(%{start_key} != %{finish_key}) OR (%{start_key} IS NULL) OR (%{finish_key} IS NULL)"
         }
       }[appropriate_db_type(klass)]
     end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -252,6 +252,7 @@ describe StateOfTheNation do
     let(:pres4) { country.presidents.create!(entered_office_at: day(15), left_office_at: day(22)) }
     let(:pres5) { President.create!(entered_office_at: pres1.entered_office_at, left_office_at: pres1.left_office_at) }
     let(:pres6) { country.presidents.create!(entered_office_at: day(5), left_office_at: day(5)) }
+    let(:pres7) { country.presidents.create!(entered_office_at: day(6), left_office_at: nil)}
 
     it "raises an exception if multiple active would have occurred from creation" do
       expect { pres1; pres2 }.to raise_error StateOfTheNation::ConflictError
@@ -276,6 +277,16 @@ describe StateOfTheNation do
       allow(President).to receive(:ignore_empty).and_return(true)
 
       expect { pres6; pres1 }.not_to raise_error
+    end
+
+    it "unterminated existing model are considered active" do
+      expect { pres7; pres1 }.to raise_error StateOfTheNation::ConflictError
+    end
+
+    it "unterminated existing model are considered active when empty intervals are ignored" do
+      allow(President).to receive(:ignore_empty).and_return(true)
+
+      expect { pres7; pres1 }.to raise_error StateOfTheNation::ConflictError
     end
 
     it "does nothing if prevent_multiple_active is set to false" do

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -254,6 +254,7 @@ describe StateOfTheNation do
     let(:pres6) { country.presidents.create!(entered_office_at: day(5), left_office_at: day(5)) }
     let(:pres7) { country.presidents.create!(entered_office_at: day(6), left_office_at: nil)}
 
+
     it "raises an exception if multiple active would have occurred from creation" do
       expect { pres1; pres2 }.to raise_error StateOfTheNation::ConflictError
     end


### PR DESCRIPTION
In an app consuming this gem, we encountered problems with the `considered_active(ignore_empty: true)` functionality that aims to ignore events with the same activation and deactivation date. It worked in cases where a deliberate deactivation had been set, but it started filtering out non-terminated periods when considering `other_records_in_range`. 

This was an artifact of how SQL treats comparisons with NULL.

> You cannot use arithmetic comparison operators such as =, <, or <> to test for NULL.
> The result of any arithmetic comparison with NULL is also NULL  
https://dev.mysql.com/doc/refman/8.0/en/working-with-null.html

This meant that the previous query checking that start != finish always returned NULL/false for records with a NULL end, filtering out records that should be considered to conflict.
```ruby
%{start_key} != %{finish_key}
```

By making sure our not equal comparison only filters out values where neither key is NULL, we can ensure we don't filter out these records.
```ruby
(%{start_key} != %{finish_key}) OR (%{start_key} IS NULL) OR (%{finish_key} IS NULL)
```


Evidence of incorrect functionality encountered that led to this change
```
# created a subscription (removed irrelevant fields)
#<Subscription:0x00007fdeaa2ce4b8
  id: 1,
  cancelled_at: nil,
  started_at: Tue, 25 Feb 2020 16:43:03 UTC +00:00>
Subscription.where("started_at != cancelled_at").count
=> 0
Subscription.where("(cancelled_at IS NULL OR started_at != cancelled_at)").count
=> 1
Subscription.where("cancelled_at = NULL").count
=> 0
Subscription.where("cancelled_at IS NULL").count
=> 1
```  