### PR TITLE
Add active_in_interval as instance variable on models

### DIFF
--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -30,7 +30,7 @@ module StateOfTheNation
           (finish.blank? || round_if_should(finish) > round_if_should(time)) && round_if_should(start) <= round_if_should(time)
         end
 
-        define_method "active_in_interval?" do |interval_start:, interval_end: nil|
+        define_method "active_in_interval?" do |interval_start:, interval_end:|
           record_start = round_if_should(start)
           record_end = round_if_should(finish)
           if ignore_empty && record_start == record_end

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -40,8 +40,7 @@ module StateOfTheNation
           elsif interval_start.nil?
             record_start < interval_end
           elsif interval_end.nil?
-            return true if record_end.nil? || record_end > interval_start
-            false
+            record_end.nil? || record_end > interval_start
           elsif record_end.nil?
             return true if interval_end > record_start
             false

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -37,6 +37,8 @@ module StateOfTheNation
             false
           elsif interval_start.nil? && interval_end.nil?
             true
+          elsif interval_start == interval_end
+            active?(interval_start)
           elsif interval_start.nil?
             record_start < interval_end
           elsif interval_end.nil?

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -30,7 +30,7 @@ module StateOfTheNation
           (finish.blank? || round_if_should(finish) > round_if_should(time)) && round_if_should(start) <= round_if_should(time)
         end
 
-        define_method "active_in_interval?" do |interval_start:, interval_end:|
+        define_method "active_in_interval?" do |interval_start, interval_end|
           record_start = round_if_should(start)
           record_end = round_if_should(finish)
           if ignore_empty && record_start == record_end

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -30,6 +30,14 @@ module StateOfTheNation
           (finish.blank? || round_if_should(finish) > round_if_should(time)) && round_if_should(start) <= round_if_should(time)
         end
 
+        define_method "active_in_interval?" do |from_time, until_time = nil|
+          start_less_than_until_or_until_is_nil = (until_time.nil? || round_if_should(start) < until_time)
+          finish_after_start_or_finish_is_nil = (finish.nil? || round_if_should(finish) > from_time)
+          start_and_finish_not_equal_or_are_nil = (start != finish || start.nil? || finish.nil?)
+          return true if start_less_than_until_or_until_is_nil && finish_after_start_or_finish_is_nil && start_and_finish_not_equal_or_are_nil
+          return true if start_less_than_until_or_until_is_nil && finish_after_start_or_finish_is_nil && !ignore_empty
+        end
+
         scope :active, lambda { |time = Time.now.utc|
           where(QueryString.query_for(:active_scope, self), round_if_should(time), round_if_should(time))
         }

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -38,8 +38,7 @@ module StateOfTheNation
           elsif interval_start.nil? && interval_end.nil?
             true
           elsif interval_start.nil?
-            return true if record_start < interval_end
-            false
+            record_start < interval_end
           elsif interval_end.nil?
             return true if record_end.nil? || record_end > interval_start
             false

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -31,11 +31,24 @@ module StateOfTheNation
         end
 
         define_method "active_in_interval?" do |interval_start:, interval_end: nil|
-          start_before_interval_finish_or_comparison_with_nil = (start.nil? || interval_end.nil? || round_if_should(start) < interval_end)
-          finish_after_interval_start_or_comparison_with_nil = (finish.nil? || interval_start.nil? || round_if_should(finish) > interval_start)
-          start_and_finish_not_equal_or_are_nil = (start != finish || start.nil? || finish.nil?)
-          return true if start_before_interval_finish_or_comparison_with_nil && finish_after_interval_start_or_comparison_with_nil && start_and_finish_not_equal_or_are_nil
-          return true if start_before_interval_finish_or_comparison_with_nil && finish_after_interval_start_or_comparison_with_nil && !ignore_empty
+          record_start = round_if_should(start)
+          record_end = round_if_should(finish)
+          if ignore_empty && record_start == record_end
+            false
+          elsif interval_start.nil? && interval_end.nil?
+            true
+          elsif interval_start.nil?
+            return true if record_start < interval_end
+            false
+          elsif interval_end.nil?
+            return true if record_end.nil? || record_end > interval_start
+            false
+          elsif record_end.nil?
+            return true if interval_end > record_start
+            false
+          else
+            record_start < interval_end && interval_start < record_end
+          end
         end
 
         scope :active, lambda { |time = Time.now.utc|

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -46,7 +46,7 @@ module StateOfTheNation
           elsif record_end.nil?
             interval_end > record_start
           else
-            record_start < interval_end && interval_start < record_end
+            record_start < interval_end && record_end > interval_start
           end
         end
 

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -42,8 +42,7 @@ module StateOfTheNation
           elsif interval_end.nil?
             record_end.nil? || record_end > interval_start
           elsif record_end.nil?
-            return true if interval_end > record_start
-            false
+            interval_end > record_start
           else
             record_start < interval_end && interval_start < record_end
           end

--- a/lib/state_of_the_nation.rb
+++ b/lib/state_of_the_nation.rb
@@ -30,12 +30,12 @@ module StateOfTheNation
           (finish.blank? || round_if_should(finish) > round_if_should(time)) && round_if_should(start) <= round_if_should(time)
         end
 
-        define_method "active_in_interval?" do |from_time, until_time = nil|
-          start_less_than_until_or_until_is_nil = (until_time.nil? || round_if_should(start) < until_time)
-          finish_after_start_or_finish_is_nil = (finish.nil? || round_if_should(finish) > from_time)
+        define_method "active_in_interval?" do |interval_start:, interval_end: nil|
+          start_before_interval_finish_or_comparison_with_nil = (start.nil? || interval_end.nil? || round_if_should(start) < interval_end)
+          finish_after_interval_start_or_comparison_with_nil = (finish.nil? || interval_start.nil? || round_if_should(finish) > interval_start)
           start_and_finish_not_equal_or_are_nil = (start != finish || start.nil? || finish.nil?)
-          return true if start_less_than_until_or_until_is_nil && finish_after_start_or_finish_is_nil && start_and_finish_not_equal_or_are_nil
-          return true if start_less_than_until_or_until_is_nil && finish_after_start_or_finish_is_nil && !ignore_empty
+          return true if start_before_interval_finish_or_comparison_with_nil && finish_after_interval_start_or_comparison_with_nil && start_and_finish_not_equal_or_are_nil
+          return true if start_before_interval_finish_or_comparison_with_nil && finish_after_interval_start_or_comparison_with_nil && !ignore_empty
         end
 
         scope :active, lambda { |time = Time.now.utc|

--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.1.4"
+  VERSION = "1.1.5"
 end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -246,8 +246,8 @@ describe StateOfTheNation do
   end
 
   context ".active_in_period" do
-    let(:unbounded_president) { country.presidents.create!(entered_office_at: day(4), left_office_at: nil) }
     let(:bounded_president) { country.presidents.create!(entered_office_at: day(1), left_office_at: day(4)) }
+    let(:unbounded_president) { country.presidents.create!(entered_office_at: day(4), left_office_at: nil) }
     let(:president_with_empty_active_period) { country.presidents.create!(entered_office_at: day(4), left_office_at: day(4)) }
 
     it "returns true for records that are active in the interval" do
@@ -260,6 +260,7 @@ describe StateOfTheNation do
       expect(unbounded_president).to be_active_in_interval(day(4), nil)
       expect(unbounded_president).to be_active_in_interval(nil, day(12))
       expect(unbounded_president).to be_active_in_interval(nil, nil)
+      expect(unbounded_president).to be_active_in_interval(day(4), day(4))
     end
 
     it "returns true for records with an empty activation period in the range" do
@@ -281,20 +282,6 @@ describe StateOfTheNation do
       expect(president_with_empty_active_period).not_to be_active_in_interval( nil, day(4))
     end
 
-    context "for records without a start date set" do
-      before do
-        travel_to(day(30))
-      end
-
-      let(:open_started_president) { country.presidents.create!(entered_office_at: nil, left_office_at: day(60)) }
-
-      it "deems them to be active from now" do
-        expect(open_started_president).not_to be_active_in_interval(day(25), day(30))
-        expect(open_started_president).to be_active_in_interval(day(30), day(35))
-      end
-
-    end
-
     context "with ignore_empty as true" do
       before do
         allow(President).to receive(:ignore_empty).and_return(true)
@@ -310,6 +297,7 @@ describe StateOfTheNation do
         expect(unbounded_president).to be_active_in_interval(day(4), nil)
         expect(unbounded_president).to be_active_in_interval(nil, day(12))
         expect(unbounded_president).to be_active_in_interval(nil, nil)
+        expect(unbounded_president).to be_active_in_interval(day(4), day(4))
       end
 
       it "returns false for records with an empty activation period in the range" do
@@ -329,6 +317,20 @@ describe StateOfTheNation do
         expect(president_with_empty_active_period).not_to be_active_in_interval(day(4), day(6))
         expect(president_with_empty_active_period).not_to be_active_in_interval(day(4), nil)
         expect(president_with_empty_active_period).not_to be_active_in_interval( nil, day(4))
+      end
+
+    end
+
+    context "for records without a start date set" do
+      before do
+        travel_to(day(30))
+      end
+
+      let(:open_started_president) { country.presidents.create!(entered_office_at: nil, left_office_at: day(60)) }
+
+      it "deems them to be active from now" do
+        expect(open_started_president).not_to be_active_in_interval(day(25), day(30))
+        expect(open_started_president).to be_active_in_interval(day(30), day(35))
       end
 
     end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -146,7 +146,6 @@ describe StateOfTheNation do
       end
     end
 
-
     it "works" do
       expect(President.active(day(6))).to eq [washington]
       expect(President.active(day(12))).to eq [roosevelt]
@@ -252,34 +251,34 @@ describe StateOfTheNation do
     let(:president_with_empty_active_period) { country.presidents.create!(entered_office_at: day(4), left_office_at: day(4)) }
 
     it "returns true for records that are active in the interval" do
-      expect(bounded_president).to be_active_in_interval(interval_start: day(3), interval_end: day(7))
-      expect(bounded_president).to be_active_in_interval(interval_start: day(3), interval_end: nil)
-      expect(bounded_president).to be_active_in_interval(interval_start: nil, interval_end: day(3))
-      expect(bounded_president).to be_active_in_interval(interval_start: nil, interval_end: nil)
+      expect(bounded_president).to be_active_in_interval(day(3), day(7))
+      expect(bounded_president).to be_active_in_interval(day(3), nil)
+      expect(bounded_president).to be_active_in_interval(nil, day(3))
+      expect(bounded_president).to be_active_in_interval(nil, nil)
 
-      expect(unbounded_president).to be_active_in_interval(interval_start: day(4), interval_end: day(12))
-      expect(unbounded_president).to be_active_in_interval(interval_start: day(4), interval_end: nil)
-      expect(unbounded_president).to be_active_in_interval(interval_start: nil, interval_end: day(12))
-      expect(unbounded_president).to be_active_in_interval(interval_start: nil, interval_end: nil)
+      expect(unbounded_president).to be_active_in_interval(day(4), day(12))
+      expect(unbounded_president).to be_active_in_interval(day(4), nil)
+      expect(unbounded_president).to be_active_in_interval(nil, day(12))
+      expect(unbounded_president).to be_active_in_interval(nil, nil)
     end
 
     it "returns true for records with an empty activation period in the range" do
-      expect(president_with_empty_active_period).to be_active_in_interval(interval_start: day(3), interval_end: day(5))
-      expect(president_with_empty_active_period).to be_active_in_interval(interval_start: day(3), interval_end: nil)
-      expect(president_with_empty_active_period).to be_active_in_interval(interval_start: nil, interval_end: day(5))
-      expect(president_with_empty_active_period).to be_active_in_interval(interval_start: nil, interval_end: nil)
+      expect(president_with_empty_active_period).to be_active_in_interval(day(3), day(5))
+      expect(president_with_empty_active_period).to be_active_in_interval(day(3), nil)
+      expect(president_with_empty_active_period).to be_active_in_interval(nil, day(5))
+      expect(president_with_empty_active_period).to be_active_in_interval(nil, nil)
     end
 
     it "returns false for records active outside the range" do
-      expect(bounded_president).not_to be_active_in_interval(interval_start: day(4), interval_end: day(7))
-      expect(bounded_president).not_to be_active_in_interval(interval_start: day(4), interval_end: nil)
+      expect(bounded_president).not_to be_active_in_interval(day(4), day(7))
+      expect(bounded_president).not_to be_active_in_interval(day(4), nil)
 
-      expect(unbounded_president).not_to be_active_in_interval(interval_start: day(2), interval_end: day(4))
-      expect(unbounded_president).not_to be_active_in_interval(interval_start: nil, interval_end: day(4))
+      expect(unbounded_president).not_to be_active_in_interval(day(2), day(4))
+      expect(unbounded_president).not_to be_active_in_interval(nil, day(4))
 
-      expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(4), interval_end: day(6))
-      expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(4), interval_end: nil)
-      expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start:  nil, interval_end: day(4))
+      expect(president_with_empty_active_period).not_to be_active_in_interval(day(4), day(6))
+      expect(president_with_empty_active_period).not_to be_active_in_interval(day(4), nil)
+      expect(president_with_empty_active_period).not_to be_active_in_interval( nil, day(4))
     end
 
     context "for records without a start date set" do
@@ -290,8 +289,8 @@ describe StateOfTheNation do
       let(:open_started_president) { country.presidents.create!(entered_office_at: nil, left_office_at: day(60)) }
 
       it "deems them to be active from now" do
-        expect(open_started_president).not_to be_active_in_interval(interval_start: day(25), interval_end: day(30))
-        expect(open_started_president).to be_active_in_interval(interval_start: day(30), interval_end: day(35))
+        expect(open_started_president).not_to be_active_in_interval(day(25), day(30))
+        expect(open_started_president).to be_active_in_interval(day(30), day(35))
       end
 
     end
@@ -302,34 +301,34 @@ describe StateOfTheNation do
       end
 
       it "returns true for records that are active in the interval" do
-        expect(bounded_president).to be_active_in_interval(interval_start: day(3), interval_end: day(7))
-        expect(bounded_president).to be_active_in_interval(interval_start: day(3), interval_end: nil)
-        expect(bounded_president).to be_active_in_interval(interval_start: nil, interval_end: day(3))
-        expect(bounded_president).to be_active_in_interval(interval_start: nil, interval_end: nil)
+        expect(bounded_president).to be_active_in_interval(day(3), day(7))
+        expect(bounded_president).to be_active_in_interval(day(3), nil)
+        expect(bounded_president).to be_active_in_interval(nil, day(3))
+        expect(bounded_president).to be_active_in_interval(nil, nil)
 
-        expect(unbounded_president).to be_active_in_interval(interval_start: day(4), interval_end: day(12))
-        expect(unbounded_president).to be_active_in_interval(interval_start: day(4), interval_end: nil)
-        expect(unbounded_president).to be_active_in_interval(interval_start: nil, interval_end: day(12))
-        expect(unbounded_president).to be_active_in_interval(interval_start: nil, interval_end: nil)
+        expect(unbounded_president).to be_active_in_interval(day(4), day(12))
+        expect(unbounded_president).to be_active_in_interval(day(4), nil)
+        expect(unbounded_president).to be_active_in_interval(nil, day(12))
+        expect(unbounded_president).to be_active_in_interval(nil, nil)
       end
 
       it "returns false for records with an empty activation period in the range" do
-        expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(3), interval_end: day(5))
-        expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(3), interval_end: nil)
-        expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: nil, interval_end: day(5))
-        expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: nil, interval_end: nil)
+        expect(president_with_empty_active_period).not_to be_active_in_interval(day(3), day(5))
+        expect(president_with_empty_active_period).not_to be_active_in_interval(day(3), nil)
+        expect(president_with_empty_active_period).not_to be_active_in_interval(nil, day(5))
+        expect(president_with_empty_active_period).not_to be_active_in_interval(nil, nil)
       end
 
       it "returns false for records active outside the range" do
-        expect(bounded_president).not_to be_active_in_interval(interval_start: day(4), interval_end: day(7))
-        expect(bounded_president).not_to be_active_in_interval(interval_start: day(4), interval_end: nil)
+        expect(bounded_president).not_to be_active_in_interval(day(4), day(7))
+        expect(bounded_president).not_to be_active_in_interval(day(4), nil)
 
-        expect(unbounded_president).not_to be_active_in_interval(interval_start: day(2), interval_end: day(4))
-        expect(unbounded_president).not_to be_active_in_interval(interval_start: nil, interval_end: day(4))
+        expect(unbounded_president).not_to be_active_in_interval(day(2), day(4))
+        expect(unbounded_president).not_to be_active_in_interval(nil, day(4))
 
-        expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(4), interval_end: day(6))
-        expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(4), interval_end: nil)
-        expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start:  nil, interval_end: day(4))
+        expect(president_with_empty_active_period).not_to be_active_in_interval(day(4), day(6))
+        expect(president_with_empty_active_period).not_to be_active_in_interval(day(4), nil)
+        expect(president_with_empty_active_period).not_to be_active_in_interval( nil, day(4))
       end
 
     end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -146,6 +146,7 @@ describe StateOfTheNation do
       end
     end
 
+
     it "works" do
       expect(President.active(day(6))).to eq [washington]
       expect(President.active(day(12))).to eq [roosevelt]
@@ -279,6 +280,20 @@ describe StateOfTheNation do
       expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(4), interval_end: day(6))
       expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start: day(4), interval_end: nil)
       expect(president_with_empty_active_period).not_to be_active_in_interval(interval_start:  nil, interval_end: day(4))
+    end
+
+    context "for records without a start date set" do
+      before do
+        travel_to(day(30))
+      end
+
+      let(:open_started_president) { country.presidents.create!(entered_office_at: nil, left_office_at: day(60)) }
+
+      it "deems them to be active from now" do
+        expect(open_started_president).not_to be_active_in_interval(interval_start: day(25), interval_end: day(30))
+        expect(open_started_president).to be_active_in_interval(interval_start: day(30), interval_end: day(35))
+      end
+
     end
 
     context "with ignore_empty as true" do


### PR DESCRIPTION
This looks to introduce the concept of `active_in_interval` to record with a StateOfTheNation considered_active period.

It aims to capture the concept of a record being active at any point in the interval, facilitating checks like whether a record was ever active in the past, or will ever become active in the future. 

During the set-up of `considered_active` on a model, we additionally inject a new `active_in_interval` instance method that takes a start and end date and determines whether the models start and end dates create an activation period that intersects with the period provided. 