### PR TITLE
Remove time rounding as a breaking change

### DIFF
--- a/lib/state_of_the_nation/version.rb
+++ b/lib/state_of_the_nation/version.rb
@@ -1,3 +1,3 @@
 module StateOfTheNation
-  VERSION = "1.1.6"
+  VERSION = "2.0.0"
 end

--- a/spec/state_of_the_nation_spec.rb
+++ b/spec/state_of_the_nation_spec.rb
@@ -169,6 +169,17 @@ describe StateOfTheNation do
       expect(roosevelt).not_to be_active(day(15))
     end
 
+    it "works on time boundaries" do
+      boundary = Time.new(2017, 1, 20, 23, 59, 59)
+      # add in the microseconds to make this _really_ boundaryish
+      boundary = Time.at(boundary.to_i + 0.999999)
+      after_boundary = Time.new(2017, 1, 21)
+      obama.update!(left_office_at: after_boundary)
+
+      expect(obama).to be_active(boundary)
+      expect(obama).not_to be_active(after_boundary)
+    end
+
     it "works when nothing active" do
       expect(President.active(day(9))).to eq []
 
@@ -419,31 +430,6 @@ describe StateOfTheNation do
           expect { pres1 }.to raise_error StateOfTheNation::ConfigurationError
         end
       end
-    end
-  end
-
-  context "#should_round_timestamps?" do
-    let(:country) { Country.create }
-    let!(:washington) { country.presidents.create!(entered_office_at: day(1), left_office_at: day(8)) }
-    let(:sub_second_timestamp) { 1270643035.04671 }
-    let(:sub_second_time) { Time.at(sub_second_timestamp)  }
-
-    it "is true for MySQL" do
-      allow(President).to receive_message_chain(:connection, :adapter_name).
-        and_return("MySQL")
-      expect(washington.send(:should_round_timestamps?)).to eq(true)
-    end
-
-    it "is false for PostgreSQL" do
-      allow(President).to receive_message_chain(:connection, :adapter_name).
-                           and_return("PostgreSQL")
-      expect(washington.send(:should_round_timestamps?)).to eq(false)
-    end
-
-    it "is true for SQLite" do
-      allow(President).to receive_message_chain(:connection, :adapter_name).
-                           and_return("SQLite")
-      expect(washington.send(:should_round_timestamps?)).to eq(true)
     end
   end
 


### PR DESCRIPTION
StateOfTheNation models an interval that's open at the start and closed at the end (i.e. it includes the start and excludes the end), and rounding timestamps doesn't allow us to strictly use it that way.

For example, ActiveSupport's `end_of_day` convenience method returns a timestamp that includes 999,999 microseconds, but is still within the day and should be included in the active period of an object that's made inactive at the start of the next day.